### PR TITLE
client: Add timed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- aprs client: Added the possibility of a timed callback
+
 ## 0.3.0 - 2016-03-18
 The repository ogn-python splitted up into two separate repositories:
   - python-ogn-client (the repository this Changelog belongs to),

--- a/ogn/client/client.py
+++ b/ogn/client/client.py
@@ -45,14 +45,15 @@ class AprsClient:
         except OSError:
             self.logger.error('Socket close error', exc_info=True)
 
-    def run(self, callback, autoreconnect=False):
+    def run(self, callback, timed_callback=lambda client: None, autoreconnect=False):
         while True:
             try:
                 keepalive_time = time()
                 while True:
                     if time() - keepalive_time > settings.APRS_KEEPALIVE_TIME:
                         self.logger.info('Send keepalive')
-                        self.sock.send('#keepalive'.encode())
+                        self.sock.send('#keepalive\n'.encode())
+                        timed_callback(self)
                         keepalive_time = time()
 
                     # Read packet string from socket


### PR DESCRIPTION
A timed callback allows the modification of server-side filters
during runtime (the client instance provided as callback argument
includes the socket and its send function).

Since sock_file.readline() is blocking, a secure scheduling can't
be guaranteed but is likely due to regular server-sent status messages.