### PR TITLE
Relax APRS packet parser pattern to allow other destination calls than APRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Parse APRS/OGN packet.
 from ogn.parser import parse_aprs, parse_ogn_beacon
 from datetime import datetime
 
-beacon = parse_aprs("FLRDDDEAD>APRS,qAS,EDER:/114500h5029.86N/00956.98E'342/049/A=005524 id0ADDDEAD -454fpm -1.1rot 8.8dB 0e +51.2kHz gps4x5",
+beacon = parse_aprs("FLRDDDEAD>OGN,qAS,EDER:/114500h5029.86N/00956.98E'342/049/A=005524 id0ADDDEAD -454fpm -1.1rot 8.8dB 0e +51.2kHz gps4x5",
                     reference_date=datetime(2016,1,1,11,46))
 beacon.update(parse_ogn_beacon(beacon['comment']))
 ```

--- a/ogn/parser/parse.py
+++ b/ogn/parser/parse.py
@@ -14,6 +14,7 @@ def parse_aprs(message, reference_date=None):
     if match:
         return {'name': match.group('callsign'),
                 'receiver_name': match.group('receiver'),
+                'dstcall': match.group('dstcall'),
                 'timestamp': createTimestamp(match.group('time'), reference_date),
                 'latitude': dmsToDeg(float(match.group('latitude')) / 100) *
                 (-1 if match.group('latitude_sign') == 'S' else 1) +

--- a/ogn/parser/pattern.py
+++ b/ogn/parser/pattern.py
@@ -1,7 +1,7 @@
 import re
 
 
-PATTERN_APRS = re.compile(r"^(?P<callsign>.+?)>APRS,.+,(?P<receiver>.+?):/(?P<time>\d{6})+h(?P<latitude>\d{4}\.\d{2})(?P<latitude_sign>N|S)(?P<symbol_table>.)(?P<longitude>\d{5}\.\d{2})(?P<longitude_sign>E|W)(?P<symbol>.)(?P<course_extension>(?P<course>\d{3})/(?P<ground_speed>\d{3}))?/A=(?P<altitude>\d{6})(?P<pos_extension>\s!W((?P<latitude_enhancement>\d)(?P<longitude_enhancement>\d))!)?\s(?P<comment>.*)$")
+PATTERN_APRS = re.compile(r"^(?P<callsign>.+?)>(?P<dstcall>[A-Z0-9]+),.+,(?P<receiver>.+?):/(?P<time>\d{6})+h(?P<latitude>\d{4}\.\d{2})(?P<latitude_sign>N|S)(?P<symbol_table>.)(?P<longitude>\d{5}\.\d{2})(?P<longitude_sign>E|W)(?P<symbol>.)(?P<course_extension>(?P<course>\d{3})/(?P<ground_speed>\d{3}))?/A=(?P<altitude>\d{6})(?P<pos_extension>\s!W((?P<latitude_enhancement>\d)(?P<longitude_enhancement>\d))!)?\s(?P<comment>.*)$")
 
 # The following regexp patterns are part of the ruby ogn-client.
 # source: https://github.com/svoop/ogn_client-ruby


### PR DESCRIPTION
APRS spec allows any callsign-like string, and it is widely used to signal which software or device generated the packet.

For OGN use, I would recommend using OGN-specific destination callsigns, maybe software/tracker-specific OGN-prefixed calls. This patch would allow those tocalls to be parsed by python-ogn-client. This would also make it easy to detect and differentiate APRS and OGN packets from each other, should the two networks be accidentally mixed.

The patch does not break existing clients or packets in any way.

APRS tocall index is found here, AP-prefixed tocalls are used for APRS devices:
https://github.com/hessu/aprs-deviceid/blob/master/tocalls.yaml