### PR TITLE
modified to digest reference_date, if given

### DIFF
--- a/ogn/parser/parse.py
+++ b/ogn/parser/parse.py
@@ -9,6 +9,8 @@ from ogn.parser.exceptions import AprsParseError, OgnParseError
 def parse_aprs(message, reference_date=None):
     if reference_date is None:
         reference_date = datetime.utcnow()
+    else:
+        reference_date = datetime.strptime(reference_date, "%Y-%m-%d")
 
     match = re.search(PATTERN_APRS, message)
     if match:


### PR DESCRIPTION
This PR is to enable python-ogn-client to digest reference dates provided by argument. 