### PR TITLE
Add kill flag to AprsClient

### DIFF
--- a/ogn/client/client.py
+++ b/ogn/client/client.py
@@ -38,6 +38,8 @@ class AprsClient:
         self.sock.send(login.encode())
         self.sock_file = self.sock.makefile('rw')
 
+        self._kill = False
+
     def disconnect(self):
         self.logger.info('Disconnect')
         try:

--- a/tests/client/test_AprsClient.py
+++ b/tests/client/test_AprsClient.py
@@ -44,6 +44,28 @@ class OgnClientTest(unittest.TestCase):
         client.sock.close.assert_called_once_with()
         self.assertTrue(client._kill)
 
+    def test_reset_kill_reconnect(self):
+        client = AprsClient(aprs_user='testuser', aprs_filter='')
+        client.connect()
+
+        # .run() should be allowed to execute after .connect()
+        mock_callback = mock.MagicMock(
+            side_effect=lambda raw_msg: client.disconnect())
+
+        self.assertFalse(client._kill)
+        client.run(callback=mock_callback, autoreconnect=True)
+
+        # After .disconnect(), client._kill should be True
+        self.assertTrue(client._kill)
+        mock_callback.assert_called_once()
+
+        # After we reconnect, .run() should be able to run again
+        mock_callback = mock.MagicMock(
+            side_effect=lambda raw_msg: client.disconnect())
+        client.connect()
+        client.run(callback=mock_callback, autoreconnect=True)
+        mock_callback.assert_called_once()
+
     def test_50_live_messages(self):
         print("Enter")
         self.remaining_messages = 50

--- a/tests/client/test_AprsClient.py
+++ b/tests/client/test_AprsClient.py
@@ -42,6 +42,7 @@ class OgnClientTest(unittest.TestCase):
         client.disconnect()
         client.sock.shutdown.assert_called_once_with(0)
         client.sock.close.assert_called_once_with()
+        self.assertTrue(client._kill)
 
     def test_50_live_messages(self):
         print("Enter")

--- a/tests/client/test_AprsClient.py
+++ b/tests/client/test_AprsClient.py
@@ -57,14 +57,13 @@ class OgnClientTest(unittest.TestCase):
 
         # After .disconnect(), client._kill should be True
         self.assertTrue(client._kill)
-        mock_callback.assert_called_once()
+        self.assertEqual(mock_callback.call_count, 1)
 
         # After we reconnect, .run() should be able to run again
-        mock_callback = mock.MagicMock(
-            side_effect=lambda raw_msg: client.disconnect())
+        mock_callback.reset_mock()
         client.connect()
         client.run(callback=mock_callback, autoreconnect=True)
-        mock_callback.assert_called_once()
+        self.assertEqual(mock_callback.call_count, 1)
 
     def test_50_live_messages(self):
         print("Enter")


### PR DESCRIPTION
When starting an AprsClient with AprsClient.run(...) the client enters
a loop without an exit condition (i.e. a while True loop).  If autoreconnect
is set to True, it is impossible to exit the aforementioned loop even if
AprsClient.disconnect() is called.

This causes problems when running the client in a thread (or as a
background service, etc.) as the process will not join nor terminate
unless explicitly shutdown with SIGKILL.

Minimal example:

```
import signal

from ogn.client import AprsClient
from ogn.parser import parse_aprs, parse_ogn_beacon, ParseError

def process_beacon(raw_message):
    print('Received message')

client = AprsClient(aprs_user='N0CALL')
signal.signal(signal.SIGTERM, lambda signo, stackno: client.disconnect())
client.connect()
client.run(callback=process_beacon, autoreconnect=True)
```

This commit fixes such issues by adding a kill flag that is raised when
calling AprsClien.disconnect() to the while conditions of both loops inside
AprsClient.run().

Note: the outermost loop could still remain a while True loop as the
exit condition is checked at the end of the loop body.