### PR TITLE
Allow dynamic settings override

### DIFF
--- a/ogn/client/__init__.py
+++ b/ogn/client/__init__.py
@@ -1,9 +1,10 @@
 from ogn.client.client import AprsClient    # noqa: F401
 from ogn.client.client import TelnetClient  # noqa: F401
 
+
 class CustomSettings(object):
     def __init__(self, **kw):
         self.kw = kw
+
     def __getattr__(self, name):
         return self.kw[name]
-

--- a/ogn/client/__init__.py
+++ b/ogn/client/__init__.py
@@ -1,2 +1,9 @@
 from ogn.client.client import AprsClient    # noqa: F401
 from ogn.client.client import TelnetClient  # noqa: F401
+
+class CustomSettings(object):
+    def __init__(self, **kw):
+        self.kw = kw
+    def __getattr__(self, name):
+        return self.kw[name]
+


### PR DESCRIPTION
Additional (optional) 'settings' attribute in AprsClient,
to be able to pass custom settings to the client,
without changing the settings.py file.

Added 'CustomSettings' class for backward compatible attribute access.

Example (myapp.py):
...
args = ... parse arguments from command line

settings = CustomSettings(
    APRS_SERVER_HOST = args.server,
    APRS_SERVER_PORT_FULL_FEED = args.port,
    APRS_SERVER_PORT_CLIENT_DEFINED_FILTERS = args.port,
    APRS_APP_NAME = 'python-ogn-client',
    PACKAGE_VERSION = '0.9.5',
    APRS_APP_VER = '0.9',
    APRS_KEEPALIVE_TIME = 240,
    TELNET_SERVER_HOST = 'localhost',
    TELNET_SERVER_PORT = 50001,
    )

client = AprsClient(aprs_user='N0CALL', aprs_filter=args.filter, settings=settings)
client.connect()
...