### PR TITLE
Fix aircraft_type decoding and add no-tracking flag decoding

### DIFF
--- a/ogn/client/client.py
+++ b/ogn/client/client.py
@@ -13,11 +13,12 @@ def create_aprs_login(user_name, pass_code, app_name, app_version, aprs_filter=N
 
 
 class AprsClient:
-    def __init__(self, aprs_user, aprs_filter='', settings=settings):
+    def __init__(self, aprs_user, aprs_passcode=-1, aprs_filter='', settings=settings):
         self.logger = logging.getLogger(__name__)
         self.logger.addHandler(logging.NullHandler())
 
         self.aprs_user = aprs_user
+        self.aprs_passcode = aprs_passcode
         self.aprs_filter = aprs_filter
         self.settings = settings
 
@@ -39,7 +40,7 @@ class AprsClient:
 
                 self.sock.connect((self.settings.APRS_SERVER_HOST, port))
 
-                login = create_aprs_login(self.aprs_user, -1, self.settings.APRS_APP_NAME, self.settings.APRS_APP_VER, self.aprs_filter)
+                login = create_aprs_login(self.aprs_user, self.aprs_passcode, self.settings.APRS_APP_NAME, self.settings.APRS_APP_VER, self.aprs_filter)
                 self.sock.send(login.encode())
                 self.sock_file = self.sock.makefile('rw')
 

--- a/ogn/parser/aprs_comment/flarm_parser.py
+++ b/ogn/parser/aprs_comment/flarm_parser.py
@@ -16,7 +16,8 @@ class FlarmParser(BaseParser):
         if match.group('details'):
             result.update({
                 'address_type': int(match.group('details'), 16) & 0b00000011,
-                'aircraft_type': (int(match.group('details'), 16) & 0b01111100) >> 2,
+                'aircraft_type': (int(match.group('details'), 16) & 0b00111100) >> 2,
+                'no-tracking': (int(match.group('details'), 16) & 0b01000000) >> 6 == 1,
                 'stealth': (int(match.group('details'), 16) & 0b10000000) >> 7 == 1,
                 'address': match.group('address'),
             })

--- a/ogn/parser/aprs_comment/ogn_parser.py
+++ b/ogn/parser/aprs_comment/ogn_parser.py
@@ -34,7 +34,8 @@ class OgnParser(BaseParser):
             if match.group('details'):
                 result.update({
                     'address_type': int(match.group('details'), 16) & 0b00000011,
-                    'aircraft_type': (int(match.group('details'), 16) & 0b01111100) >> 2,
+                    'aircraft_type': (int(match.group('details'), 16) & 0b00111100) >> 2,
+                    'no-tracking': (int(match.group('details'), 16) & 0b01000000) >> 6 == 1,
                     'stealth': (int(match.group('details'), 16) & 0b10000000) >> 7 == 1,
                     'address': match.group('address'),
                 })

--- a/tests/parser/test_parse_flarm.py
+++ b/tests/parser/test_parse_flarm.py
@@ -11,6 +11,7 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(message['address_type'], 1)
         self.assertEqual(message['aircraft_type'], 8)
         self.assertFalse(message['stealth'])
+        self.assertFalse(message['no-tracking'])
         self.assertEqual(message['address'], "A8CBA8")
         self.assertAlmostEqual(message['climb_rate'], -39 * FPM_TO_MS, 2)
         self.assertEqual(message['turn_rate'], 0.1 * HPM_TO_DEGS)
@@ -27,7 +28,7 @@ class TestStringMethods(unittest.TestCase):
         message = FlarmParser().parse_position("id21A8CBA8")
 
         self.assertIsNotNone(message)
-        self.assertEqual(sorted(message.keys()), sorted(['address_type', 'aircraft_type', 'stealth', 'address']))
+        self.assertEqual(sorted(message.keys()), sorted(['address_type', 'aircraft_type', 'stealth', 'address', 'no-tracking']))
 
 
 if __name__ == '__main__':

--- a/tests/parser/test_parse_ogn_aircraft.py
+++ b/tests/parser/test_parse_ogn_aircraft.py
@@ -14,6 +14,7 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(message['address_type'], 2)
         self.assertEqual(message['aircraft_type'], 2)
         self.assertFalse(message['stealth'])
+        self.assertFalse(message['no-tracking'])
         self.assertEqual(message['address'], "DDA5BA")
         self.assertAlmostEqual(message['climb_rate'], -454 * FPM_TO_MS, 2)
         self.assertEqual(message['turn_rate'], -1.1 * HPM_TO_DEGS)
@@ -25,6 +26,13 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(message['proximity'][0], '1084')
         self.assertEqual(message['proximity'][1], 'B597')
         self.assertEqual(message['proximity'][2], 'B598')
+
+    def test_no_tracking(self):
+        message = OgnParser().parse_aircraft_beacon("id0ADD1234 -454fpm -1.1rot 8.8dB 0e +51.2kHz gps4x5 hear1084 hearB597 hearB598")
+        self.assertFalse(message['no-tracking'])
+
+        message = OgnParser().parse_aircraft_beacon("id4ADD1234 -454fpm -1.1rot 8.8dB 0e +51.2kHz gps4x5 hear1084 hearB597 hearB598")
+        self.assertTrue(message['no-tracking'])
 
     def test_stealth(self):
         message = OgnParser().parse_aircraft_beacon("id0ADD1234 -454fpm -1.1rot 8.8dB 0e +51.2kHz gps4x5 hear1084 hearB597 hearB598")
@@ -63,7 +71,7 @@ class TestStringMethods(unittest.TestCase):
         message = OgnParser().parse_aircraft_beacon("id093D0930")
 
         self.assertIsNotNone(message)
-        self.assertEqual(sorted(message.keys()), sorted(['address_type', 'aircraft_type', 'stealth', 'address']))
+        self.assertEqual(sorted(message.keys()), sorted(['address_type', 'aircraft_type', 'stealth', 'address', 'no-tracking']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Received on March 12 the following aprs packet `FLRF8AC70>APRS,qAS,Neuenburg:/143646h4342.00NM00232.06E^057/027/A=021374 !W39! idF2F8AC70 +7047fpm +0.0rot 79.0dB 0e -0.0kHz`
The parser return 28 as aircraft_type instead of 12.

From [OGN APRS Protocol](http://wiki.glidernet.org/wiki:ogn-flavoured-aprs), I see that XX from idXXYYYYYY encodes stealth mode S, no-tracking flag T, aircraft type tttt and address type aa as follows: STttttaa
I fix Ogn & Flarm parsers accordingly to decode properly aircraft_type and add no-tracking flag.