### PR TITLE
add decode strict arg in run method

### DIFF
--- a/ogn/client/client.py
+++ b/ogn/client/client.py
@@ -41,7 +41,7 @@ class AprsClient:
 
                 login = create_aprs_login(self.aprs_user, -1, self.settings.APRS_APP_NAME, self.settings.APRS_APP_VER, self.aprs_filter)
                 self.sock.send(login.encode())
-                self.sock_file = self.sock.makefile('rw')
+                self.sock_file = self.sock.makefile('rb')
 
                 self._kill = False
 
@@ -67,7 +67,7 @@ class AprsClient:
 
         self._kill = True
 
-    def run(self, callback, timed_callback=lambda client: None, autoreconnect=False, **kwargs):
+    def run(self, callback, timed_callback=lambda client: None, autoreconnect=False, strict=True, **kwargs):
         while not self._kill:
             try:
                 keepalive_time = time()
@@ -79,7 +79,8 @@ class AprsClient:
                         keepalive_time = time()
 
                     # Read packet string from socket
-                    packet_str = self.sock_file.readline().strip()
+                    packet_b = self.sock_file.readline().strip()
+                    packet_str = packet_b.decode() if strict else packet_b.decode(errors='ignore')
 
                     # A zero length line should not be return if keepalives are being sent
                     # A zero length line will only be returned after ~30m if keepalives are not sent
@@ -94,6 +95,7 @@ class AprsClient:
                 self.logger.error('OSError')
             except UnicodeDecodeError:
                 self.logger.error('UnicodeDecodeError')
+                self.logger.debug(packet_b)
 
             if autoreconnect and not self._kill:
                 self.connect(retries=100)

--- a/ogn/client/client.py
+++ b/ogn/client/client.py
@@ -67,7 +67,8 @@ class AprsClient:
 
         self._kill = True
 
-    def run(self, callback, timed_callback=lambda client: None, autoreconnect=False, strict=True, **kwargs):
+    def run(self, callback, timed_callback=lambda client: None, autoreconnect=False, ignore_decoding_error=True,
+            **kwargs):
         while not self._kill:
             try:
                 keepalive_time = time()
@@ -80,7 +81,7 @@ class AprsClient:
 
                     # Read packet string from socket
                     packet_b = self.sock_file.readline().strip()
-                    packet_str = packet_b.decode() if strict else packet_b.decode(errors='ignore')
+                    packet_str = packet_b.decode(errors="replace") if ignore_decoding_error else packet_b.decode()
 
                     # A zero length line should not be return if keepalives are being sent
                     # A zero length line will only be returned after ~30m if keepalives are not sent

--- a/tests/client/test_AprsClient.py
+++ b/tests/client/test_AprsClient.py
@@ -25,7 +25,7 @@ class AprsClientTest(unittest.TestCase):
         client.connect()
         client.sock.send.assert_called_once_with('user testuser pass -1 vers {} {}\n'.format(
                                                  APRS_APP_NAME, APRS_APP_VER).encode('ascii'))
-        client.sock.makefile.assert_called_once_with('rw')
+        client.sock.makefile.assert_called_once_with('rb')
 
     @mock.patch('ogn.client.client.socket')
     def test_connect_client_defined_filter(self, mock_socket):
@@ -33,7 +33,7 @@ class AprsClientTest(unittest.TestCase):
         client.connect()
         client.sock.send.assert_called_once_with('user testuser pass -1 vers {} {} filter r/50.4976/9.9495/100\n'.format(
                                                  APRS_APP_NAME, APRS_APP_VER).encode('ascii'))
-        client.sock.makefile.assert_called_once_with('rw')
+        client.sock.makefile.assert_called_once_with('rb')
 
     @mock.patch('ogn.client.client.socket')
     def test_disconnect(self, mock_socket):
@@ -53,18 +53,18 @@ class AprsClientTest(unittest.TestCase):
         client.connect()
 
         client.sock_file.readline = mock.MagicMock()
-        client.sock_file.readline.side_effect = ['Normal text blabla',
-                                                 'my weird character ¥',
+        client.sock_file.readline.side_effect = [b'Normal text blabla',
+                                                 b'my weird character \xc2\xa5',
                                                  UnicodeDecodeError('funnycodec', b'\x00\x00', 1, 2, 'This is just a fake reason!'),
-                                                 '... show must go on',
+                                                 b'... show must go on',
                                                  BrokenPipeError(),
-                                                 '... and on',
+                                                 b'... and on',
                                                  ConnectionResetError(),
-                                                 '... and on',
+                                                 b'... and on',
                                                  socket.error(),
-                                                 '... and on',
-                                                 '',
-                                                 '... and on',
+                                                 b'... and on',
+                                                 b'',
+                                                 b'... and on',
                                                  KeyboardInterrupt()]
 
         try:
@@ -84,7 +84,7 @@ class AprsClientTest(unittest.TestCase):
         client.connect()
 
         client.sock_file.readline = mock.MagicMock()
-        client.sock_file.readline.side_effect = ['Normal text blabla',
+        client.sock_file.readline.side_effect = [b'Normal text blabla',
                                                  KeyboardInterrupt()]
 
         mock_time.side_effect = [0, 0, APRS_KEEPALIVE_TIME + 1, APRS_KEEPALIVE_TIME + 1]


### PR DESCRIPTION
There's more & more UTF_8 decode errors in APRS raw message. As a consequence, socket disconnect and reconnect after the try , except catch. It can lead to APRS packet lost during this reconnect. 
I add the strict mode (True by default) but with the possibility to 'force' decode when is set to false.
Also, the write mode in socket_file is removed as the keepalive is send directly with socket.send method and not with the socket file.
A log debug level display the bad encoding string when strict is set to True (default).