### PR TITLE
Draft: Concurrent (with asyncio) AprsClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if __name__ == '__main__':
 ```
 
 ### Concurrent Example:
-Same as above, but run concurrently run your custom long running function:
+Same as above, but also concurrently execute your custom long-running function:
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ beacon = parse("FLRDDDEAD>APRS,qAS,EDER:/114500h5029.86N/00956.98E'342/049/A=005
 				reference_timestamp=datetime(2015, 7, 31, 12, 34, 56))
 ```
 
-### Connect to OGN and display all incoming beacons.
+### Simple Example:
+Connect to OGN and display all incoming beacons.
 
 ```python
+import asyncio
+
 from ogn.client import AprsClient
 from ogn.parser import parse, ParseError
+
 
 def process_beacon(raw_message):
     try:
@@ -45,15 +49,68 @@ def process_beacon(raw_message):
     except NotImplementedError as e:
         print('{}: {}'.format(e, raw_message))
 
-client = AprsClient(aprs_user='N0CALL')
-client.connect()
 
-try:
-    client.run(callback=process_beacon, autoreconnect=True)
-except KeyboardInterrupt:
-    print('\nStop ogn gateway')
-    client.disconnect()
+async def run_aprs():
+    client = AprsClient(aprs_user='N0CALL')
+    await client.connect()
+    await client.run(callback=process_beacon, autoreconnect=True)
+
+if __name__ == '__main__':
+    try:
+        asyncio.run(run_aprs())
+    except KeyboardInterrupt:
+        print('\nStop ogn gateway')
+        # await client.disconnect()
+
 ```
+
+### Concurrent Example:
+Same as above, but run concurrently run your custom long running function:
+
+```python
+import asyncio
+
+from ogn.client import AprsClient
+from ogn.parser import parse, ParseError
+
+
+def process_beacon(raw_message):
+    try:
+        beacon = parse(raw_message)
+        print('Received {aprs_type}: {raw_message}'.format(**beacon))
+    except ParseError as e:
+        print('Error, {}'.format(e.message))
+    except NotImplementedError as e:
+        print('{}: {}'.format(e, raw_message))
+
+
+async def run_aprs():
+    client = AprsClient(aprs_user='N0CALL')
+    await client.connect()
+    await client.run(callback=process_beacon, autoreconnect=True)
+
+
+async def run_another_long_running_function():
+    import datetime
+    while True:
+        print(f'The time is {datetime.datetime.now()}')
+        await asyncio.sleep(10)
+
+
+async def main():
+    await asyncio.gather(run_aprs(), run_another_long_running_function())
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+
+
+
+
+
+
 
 ### Connect to telnet console and display all decoded beacons.
 


### PR DESCRIPTION
Hi,

This draft pull request demonstrates the asynchronous/concurrent/asyncio version of AprsClient, that I normally use (I haven't touched TelnetClient or anything else.).    Besides the using a higher level abstraction than sockets, and the potential performance improvements, I find it useful to be able to execute my code concurrently, i.e. when AprsClient.run() is blocking, and independently of the callback handler. 
 
This PR obviously isn't for merging (it breaks the API)—I'm just wondering if there's any interest in me cleaning up and creating a public version?